### PR TITLE
Removed ANDROID_API_KEY

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-        <meta-data android:name="com.google.android.geo.API_KEY" android:value="AIzaSyD3BF3LlQ_jm7HkDSIni9pGeTF-98gV7iA"/>
+        <meta-data android:name="com.google.android.geo.API_KEY" android:value="ANDROID_BREAKROOM_API_KEY"/>
 
 
     </application>


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Replace hardcoded Google Maps API key with a placeholder in AndroidManifest.xml.